### PR TITLE
fix: resolve IllegalStateException in PatcherMenuEditor

### DIFF
--- a/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
+++ b/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
@@ -197,7 +197,7 @@ public class PatcherMenuEditor {
         //#endif
         if (gui instanceof GuiMainMenu) {
             int key = Keyboard.getEventKey();
-            if (Keyboard.isKeyDown(key) && !Keyboard.isRepeatEvent()) {
+            if (Keyboard.isCreated() && Keyboard.isKeyDown(key) && !Keyboard.isRepeatEvent()) {
                 int i = next + 1;
                 next = (key >> 3) * ((7 & key) + (i << 1)) == sequence[next] ? i : 0;
                 if (next > 9) {


### PR DESCRIPTION
A user in SkyClient sent this crash report last night https://hst.sh/abelanisij

I have no clue how to reproduce this and so this fix isn't tested.

```
java.lang.IllegalStateException: Keyboard must be created before you can query key state
	at org.lwjgl.input.Keyboard.isKeyDown(Keyboard.java:406)
	at club.sk1er.patcher.screen.PatcherMenuEditor.keyboardInput(PatcherMenuEditor.java:200)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_514_PatcherMenuEditor_keyboardInput_Post.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:49)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraft.client.gui.GuiScreen.func_146269_k(GuiScreen.java:535)
	at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1674)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1024)
	at net.minecraft.client.Minecraft.handler$bfk000$run(Minecraft.java:3250)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java)
	at net.minecraft.client.main.Main.main(SourceFile:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at gg.essential.loader.stage2.relaunch.Relaunch.relaunch(Relaunch.java:124)
	at gg.essential.loader.stage2.EssentialLoader.preloadEssential(EssentialLoader.java:173)
	at gg.essential.loader.stage2.EssentialLoader.loadPlatform(EssentialLoader.java:117)
	at gg.essential.loader.stage2.EssentialLoaderBase.load(EssentialLoaderBase.java:147)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at gg.essential.loader.stage1.EssentialLoaderBase.load(EssentialLoaderBase.java:293)
	at gg.essential.loader.stage1.EssentialSetupTweaker.<init>(EssentialSetupTweaker.java:44)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at gg.essential.loader.stage0.EssentialSetupTweaker.loadStage1(EssentialSetupTweaker.java:53)
	at gg.essential.loader.stage0.EssentialSetupTweaker.<init>(EssentialSetupTweaker.java:26)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at java.lang.Class.newInstance(Class.java:442)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:98)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Stacktrace:
	at org.lwjgl.input.Keyboard.isKeyDown(Keyboard.java:406)
	at club.sk1er.patcher.screen.PatcherMenuEditor.keyboardInput(PatcherMenuEditor.java:200)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_514_PatcherMenuEditor_keyboardInput_Post.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:49)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraft.client.gui.GuiScreen.func_146269_k(GuiScreen.java:535)
```